### PR TITLE
Microprofile health 2.1 integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ import javax.enterprise.context.ApplicationScoped;
 public class SuccessfulHealthCheckBean implements HealthCheck {
 
     public HealthCheckResponse call() {
-        return HealthCheckResponse.named(SuccessfulHealthCheckBean.class.getSimpleName()).up().build();
+        return HealthCheckResponse.up(SuccessfulHealthCheckBean.class.getSimpleName());
     }
 
 }
@@ -120,12 +120,12 @@ public class GithubHealthCheck implements HealthCheck {
             connection.setRequestMethod("HEAD");
 
             if (connection.getResponseCode() == 200) {
-                return HealthCheckResponse.named(GithubHealthCheck.class.getSimpleName()).up().build();
+                return HealthCheckResponse.up(GithubHealthCheck.class.getSimpleName());
             }
         } catch (Exception exception) {
             LOG.severe(exception.getMessage());
         }
-        return HealthCheckResponse.named(GithubHealthCheck.class.getSimpleName()).down().build();
+        return HealthCheckResponse.down(GithubHealthCheck.class.getSimpleName());
     }
 }
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.kumuluz.ee.health</groupId>
     <artifactId>kumuluzee-health</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
 
     <name>KumuluzEE Health</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.kumuluz.ee.health</groupId>
     <artifactId>kumuluzee-health</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
 
     <name>KumuluzEE Health</name>
 
@@ -26,7 +26,7 @@
 
         <kumuluzee.version>3.5.0</kumuluzee.version>
 
-        <microprofile-health.version>2.0.1</microprofile-health.version>
+        <microprofile-health.version>2.1</microprofile-health.version>
 
         <jackson.version>2.9.9</jackson.version>
         <jedis.version>3.0.1</jedis.version>

--- a/src/main/java/com/kumuluz/ee/health/annotations/BuiltInHealthCheck.java
+++ b/src/main/java/com/kumuluz/ee/health/annotations/BuiltInHealthCheck.java
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (c) 2014-2019 Kumuluz and/or its affiliates
+ *  and other contributors as indicated by the @author tags and
+ *  the contributor list.
+ *
+ *  Licensed under the MIT License (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  https://opensource.org/licenses/MIT
+ *
+ *  The software is provided "AS IS", WITHOUT WARRANTY OF ANY KIND, express or
+ *  implied, including but not limited to the warranties of merchantability,
+ *  fitness for a particular purpose and noninfringement. in no event shall the
+ *  authors or copyright holders be liable for any claim, damages or other
+ *  liability, whether in an action of contract, tort or otherwise, arising from,
+ *  out of or in connection with the software or the use or other dealings in the
+ *  software. See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.kumuluz.ee.health.annotations;
+
+import javax.inject.Qualifier;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * Used to decorate built-in health checks
+ */
+@Qualifier
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+public @interface BuiltInHealthCheck {
+}

--- a/src/main/java/com/kumuluz/ee/health/checks/DataSourceHealthCheck.java
+++ b/src/main/java/com/kumuluz/ee/health/checks/DataSourceHealthCheck.java
@@ -17,13 +17,15 @@
  *  out of or in connection with the software or the use or other dealings in the
  *  software. See the License for the specific language governing permissions and
  *  limitations under the License.
-*/
+ */
 package com.kumuluz.ee.health.checks;
 
 import com.kumuluz.ee.configuration.utils.ConfigurationUtil;
+import com.kumuluz.ee.health.annotations.BuiltInHealthCheck;
 import org.eclipse.microprofile.health.HealthCheck;
 import org.eclipse.microprofile.health.HealthCheckResponse;
 
+import javax.enterprise.context.ApplicationScoped;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
@@ -37,7 +39,9 @@ import java.util.logging.Logger;
  * @author Marko Škrjanec
  * @since 1.0.0
  */
-public class DataSourceHealthCheck implements HealthCheck {
+@ApplicationScoped
+@BuiltInHealthCheck
+public class DataSourceHealthCheck extends KumuluzHealthCheck implements HealthCheck {
 
     private static final Logger LOG = Logger.getLogger(DataSourceHealthCheck.class.getName());
 
@@ -62,6 +66,21 @@ public class DataSourceHealthCheck implements HealthCheck {
                 }
             }
         }
+    }
+
+    @Override
+    public String name() {
+        return kumuluzBaseHealthConfigPath + "data-source-health-check";
+    }
+
+    @Override
+    public boolean initSuccess() {
+        if (!DriverManager.getDrivers().hasMoreElements()) {
+            LOG.severe("No database driver library appears to be provided.");
+            return false;
+        }
+
+        return true;
     }
 
     /**

--- a/src/main/java/com/kumuluz/ee/health/checks/DataSourceHealthCheck.java
+++ b/src/main/java/com/kumuluz/ee/health/checks/DataSourceHealthCheck.java
@@ -51,11 +51,11 @@ public class DataSourceHealthCheck extends KumuluzHealthCheck implements HealthC
 
         try {
             connection = getConnection();
-            return HealthCheckResponse.named(DataSourceHealthCheck.class.getSimpleName()).up().build();
+            return HealthCheckResponse.up(DataSourceHealthCheck.class.getSimpleName());
         } catch (Exception exception) {
             LOG.log(Level.SEVERE, "An exception occurred when trying to establish connection to data source.",
                     exception);
-            return HealthCheckResponse.named(DataSourceHealthCheck.class.getSimpleName()).down().build();
+            return HealthCheckResponse.down(DataSourceHealthCheck.class.getSimpleName());
         } finally {
             if (connection != null) {
                 try {
@@ -92,7 +92,7 @@ public class DataSourceHealthCheck extends KumuluzHealthCheck implements HealthC
     private Connection getConnection() throws SQLException {
         ConfigurationUtil configurationUtil = ConfigurationUtil.getInstance();
 
-        Optional<String> jndiName = configurationUtil.get("kumuluzee.health.checks.data-source-health-check.jndi-name");
+        Optional<String> jndiName = configurationUtil.get(name() + ".jndi-name");
         Optional<Integer> dsSizeOpt = configurationUtil.getListSize("kumuluzee.datasources");
 
         String connectionUrl = null;
@@ -112,12 +112,9 @@ public class DataSourceHealthCheck extends KumuluzHealthCheck implements HealthC
                 }
             }
         } else {
-            connectionUrl = configurationUtil.get("kumuluzee.health.checks.data-source-health-check" +
-                    ".connection-url").orElse(null);
-            username = configurationUtil.get("kumuluzee.health.checks.data-source-health-check.username")
-                    .orElse(null);
-            password = configurationUtil.get("kumuluzee.health.checks.data-source-health-check.password")
-                    .orElse(null);
+            connectionUrl = configurationUtil.get(name() + ".connection-url").orElse(null);
+            username = configurationUtil.get(name() + ".username").orElse(null);
+            password = configurationUtil.get(name() + ".password").orElse(null);
         }
 
         return username != null && password != null ? DriverManager.getConnection(connectionUrl, username, password) :

--- a/src/main/java/com/kumuluz/ee/health/checks/DiskSpaceHealthCheck.java
+++ b/src/main/java/com/kumuluz/ee/health/checks/DiskSpaceHealthCheck.java
@@ -49,19 +49,19 @@ public class DiskSpaceHealthCheck extends KumuluzHealthCheck implements HealthCh
     @Override
     public HealthCheckResponse call() {
         long threshold = ConfigurationUtil.getInstance()
-                .getLong("kumuluzee.health.checks.disk-space-health-check.threshold")
+                .getLong(name() + ".threshold")
                 .orElse(DEFAULT_THRESHOLD);
 
         try {
             if (Files.getFileStore(Paths.get("/")).getUsableSpace() >= threshold) {
-                return HealthCheckResponse.named(DiskSpaceHealthCheck.class.getSimpleName()).up().build();
+                return HealthCheckResponse.up(DiskSpaceHealthCheck.class.getSimpleName());
             } else {
                 LOG.severe("Disk space is getting low.");
-                return HealthCheckResponse.named(DiskSpaceHealthCheck.class.getSimpleName()).down().build();
+                return HealthCheckResponse.down(DiskSpaceHealthCheck.class.getSimpleName());
             }
         } catch (Exception exception) {
             LOG.log(Level.SEVERE, "An exception occurred when trying to read disk space.", exception);
-            return HealthCheckResponse.named(DiskSpaceHealthCheck.class.getSimpleName()).down().build();
+            return HealthCheckResponse.down(DiskSpaceHealthCheck.class.getSimpleName());
         }
     }
 

--- a/src/main/java/com/kumuluz/ee/health/checks/DiskSpaceHealthCheck.java
+++ b/src/main/java/com/kumuluz/ee/health/checks/DiskSpaceHealthCheck.java
@@ -17,13 +17,15 @@
  *  out of or in connection with the software or the use or other dealings in the
  *  software. See the License for the specific language governing permissions and
  *  limitations under the License.
-*/
+ */
 package com.kumuluz.ee.health.checks;
 
 import com.kumuluz.ee.configuration.utils.ConfigurationUtil;
+import com.kumuluz.ee.health.annotations.BuiltInHealthCheck;
 import org.eclipse.microprofile.health.HealthCheck;
 import org.eclipse.microprofile.health.HealthCheckResponse;
 
+import javax.enterprise.context.ApplicationScoped;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.logging.Level;
@@ -35,7 +37,9 @@ import java.util.logging.Logger;
  * @author Marko Škrjanec
  * @since 1.0.0
  */
-public class DiskSpaceHealthCheck implements HealthCheck {
+@ApplicationScoped
+@BuiltInHealthCheck
+public class DiskSpaceHealthCheck extends KumuluzHealthCheck implements HealthCheck {
 
     private static final Logger LOG = Logger.getLogger(DiskSpaceHealthCheck.class.getName());
 
@@ -59,5 +63,15 @@ public class DiskSpaceHealthCheck implements HealthCheck {
             LOG.log(Level.SEVERE, "An exception occurred when trying to read disk space.", exception);
             return HealthCheckResponse.named(DiskSpaceHealthCheck.class.getSimpleName()).down().build();
         }
+    }
+
+    @Override
+    public String name() {
+        return kumuluzBaseHealthConfigPath + "disk-space-health-check";
+    }
+
+    @Override
+    public boolean initSuccess() {
+        return true;
     }
 }

--- a/src/main/java/com/kumuluz/ee/health/checks/ElasticSearchHealthCheck.java
+++ b/src/main/java/com/kumuluz/ee/health/checks/ElasticSearchHealthCheck.java
@@ -17,13 +17,15 @@
  *  out of or in connection with the software or the use or other dealings in the
  *  software. See the License for the specific language governing permissions and
  *  limitations under the License.
-*/
+ */
 package com.kumuluz.ee.health.checks;
 
 import com.kumuluz.ee.configuration.utils.ConfigurationUtil;
+import com.kumuluz.ee.health.annotations.BuiltInHealthCheck;
 import org.eclipse.microprofile.health.HealthCheck;
 import org.eclipse.microprofile.health.HealthCheckResponse;
 
+import javax.enterprise.context.ApplicationScoped;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.WebTarget;
@@ -40,7 +42,9 @@ import java.util.logging.Logger;
  * @author Marko Škrjanec
  * @since 1.0.0
  */
-public class ElasticSearchHealthCheck implements HealthCheck {
+@ApplicationScoped
+@BuiltInHealthCheck
+public class ElasticSearchHealthCheck extends KumuluzHealthCheck implements HealthCheck {
 
     private static final Logger LOG = Logger.getLogger(ElasticSearchHealthCheck.class.getName());
     private static final Client CLIENT = ClientBuilder.newClient();
@@ -83,5 +87,15 @@ public class ElasticSearchHealthCheck implements HealthCheck {
                 response.close();
             }
         }
+    }
+
+    @Override
+    public String name() {
+        return kumuluzBaseHealthConfigPath + "elastic-search-health-check";
+    }
+
+    @Override
+    public boolean initSuccess() {
+        return true;
     }
 }

--- a/src/main/java/com/kumuluz/ee/health/checks/ElasticSearchHealthCheck.java
+++ b/src/main/java/com/kumuluz/ee/health/checks/ElasticSearchHealthCheck.java
@@ -59,7 +59,7 @@ public class ElasticSearchHealthCheck extends KumuluzHealthCheck implements Heal
     @Override
     public HealthCheckResponse call() {
         String connectionUrl = ConfigurationUtil.getInstance()
-                .get("kumuluzee.health.checks.elastic-search-health-check.connection-url")
+                .get(name() + ".connection-url")
                 .orElse(DEFAULT_CLUSTER_HEALTH_URL);
 
         WebTarget webTarget = CLIENT.target(connectionUrl);
@@ -73,15 +73,15 @@ public class ElasticSearchHealthCheck extends KumuluzHealthCheck implements Heal
                 Object status = result.get(STATUS);
 
                 if (status != null && (GREEN.equals(status.toString()) || YELLOW.equals(status.toString()))) {
-                    return HealthCheckResponse.named(ElasticSearchHealthCheck.class.getSimpleName()).up().build();
+                    return HealthCheckResponse.up(ElasticSearchHealthCheck.class.getSimpleName());
                 }
             }
 
-            return HealthCheckResponse.named(ElasticSearchHealthCheck.class.getSimpleName()).down().build();
+            return HealthCheckResponse.down(ElasticSearchHealthCheck.class.getSimpleName());
         } catch (Exception exception) {
             LOG.log(Level.SEVERE, "An exception occurred when trying to get Elasticsearch cluster status.",
                     exception);
-            return HealthCheckResponse.named(ElasticSearchHealthCheck.class.getSimpleName()).down().build();
+            return HealthCheckResponse.down(ElasticSearchHealthCheck.class.getSimpleName());
         } finally {
             if (response != null) {
                 response.close();

--- a/src/main/java/com/kumuluz/ee/health/checks/EtcdHealthCheck.java
+++ b/src/main/java/com/kumuluz/ee/health/checks/EtcdHealthCheck.java
@@ -21,10 +21,12 @@
 package com.kumuluz.ee.health.checks;
 
 import com.kumuluz.ee.configuration.utils.ConfigurationUtil;
+import com.kumuluz.ee.health.annotations.BuiltInHealthCheck;
 import org.eclipse.microprofile.health.HealthCheck;
 import org.eclipse.microprofile.health.HealthCheckResponse;
 import org.eclipse.microprofile.health.HealthCheckResponseBuilder;
 
+import javax.enterprise.context.ApplicationScoped;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.Response;
@@ -38,7 +40,9 @@ import java.util.logging.Logger;
  * @author Benjamin Kastelic
  * @since 1.0.0
  */
-public class EtcdHealthCheck implements HealthCheck {
+@ApplicationScoped
+@BuiltInHealthCheck
+public class EtcdHealthCheck extends KumuluzHealthCheck implements HealthCheck {
 
     private static final Logger LOG = Logger.getLogger(EtcdHealthCheck.class.getName());
 
@@ -90,5 +94,15 @@ public class EtcdHealthCheck implements HealthCheck {
 
         healthCheckResponseBuilder.withData(connectionUrl, HealthCheckResponse.State.DOWN.toString());
         healthCheckResponseBuilder.down();
+    }
+
+    @Override
+    public String name() {
+        return kumuluzBaseHealthConfigPath + "etcd-health-check";
+    }
+
+    @Override
+    public boolean initSuccess() {
+        return true;
     }
 }

--- a/src/main/java/com/kumuluz/ee/health/checks/EtcdHealthCheck.java
+++ b/src/main/java/com/kumuluz/ee/health/checks/EtcdHealthCheck.java
@@ -51,15 +51,16 @@ public class EtcdHealthCheck extends KumuluzHealthCheck implements HealthCheck {
     @Override
     public HealthCheckResponse call() {
         HealthCheckResponseBuilder healthCheckResponseBuilder = HealthCheckResponse.named(EtcdHealthCheck.class.getSimpleName()).up();
-        Optional<Integer> connectionUrls = ConfigurationUtil.getInstance().getListSize("kumuluzee.health.checks.etcd-health-check");
+        Optional<Integer> connectionUrls = ConfigurationUtil.getInstance().getListSize(name());
 
         if (connectionUrls.isPresent()) {
             for (int i = 0; i < connectionUrls.get(); i++) {
-                String connectionUrl = ConfigurationUtil.getInstance().get("kumuluzee.health.checks.etcd-health-check[" + i + "].connection-url").orElse("");
+                String connectionUrl =
+                        ConfigurationUtil.getInstance().get(name() + "[" + i + "].connection-url").orElse("");
                 checkEtcdStatus(connectionUrl, healthCheckResponseBuilder);
             }
         } else {
-            String connectionUrl = ConfigurationUtil.getInstance().get("kumuluzee.health.checks.etcd-health-check.connection-url").orElse("");
+            String connectionUrl = ConfigurationUtil.getInstance().get(name() + ".connection-url").orElse("");
             checkEtcdStatus(connectionUrl, healthCheckResponseBuilder);
         }
 

--- a/src/main/java/com/kumuluz/ee/health/checks/HttpHealthCheck.java
+++ b/src/main/java/com/kumuluz/ee/health/checks/HttpHealthCheck.java
@@ -17,14 +17,16 @@
  *  out of or in connection with the software or the use or other dealings in the
  *  software. See the License for the specific language governing permissions and
  *  limitations under the License.
-*/
+ */
 package com.kumuluz.ee.health.checks;
 
 import com.kumuluz.ee.configuration.utils.ConfigurationUtil;
+import com.kumuluz.ee.health.annotations.BuiltInHealthCheck;
 import org.eclipse.microprofile.health.HealthCheck;
 import org.eclipse.microprofile.health.HealthCheckResponse;
 import org.eclipse.microprofile.health.HealthCheckResponseBuilder;
 
+import javax.enterprise.context.ApplicationScoped;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.Response;
@@ -38,7 +40,9 @@ import java.util.logging.Logger;
  * @author Marko Škrjanec
  * @since 1.0.0
  */
-public class HttpHealthCheck implements HealthCheck {
+@ApplicationScoped
+@BuiltInHealthCheck
+public class HttpHealthCheck extends KumuluzHealthCheck implements HealthCheck {
 
     private static final Logger LOG = Logger.getLogger(HttpHealthCheck.class.getName());
 
@@ -92,4 +96,13 @@ public class HttpHealthCheck implements HealthCheck {
         healthCheckResponseBuilder.down();
     }
 
+    @Override
+    public String name() {
+        return kumuluzBaseHealthConfigPath + "http-health-check";
+    }
+
+    @Override
+    public boolean initSuccess() {
+        return true;
+    }
 }

--- a/src/main/java/com/kumuluz/ee/health/checks/HttpHealthCheck.java
+++ b/src/main/java/com/kumuluz/ee/health/checks/HttpHealthCheck.java
@@ -50,18 +50,15 @@ public class HttpHealthCheck extends KumuluzHealthCheck implements HealthCheck {
     public HealthCheckResponse call() {
         HealthCheckResponseBuilder healthCheckResponseBuilder = HealthCheckResponse.named(HttpHealthCheck.class
                 .getSimpleName()).up();
-        Optional<Integer> connectionUrls = ConfigurationUtil.getInstance().getListSize("kumuluzee.health.checks" +
-                ".http-health-check");
+        Optional<Integer> connectionUrls = ConfigurationUtil.getInstance().getListSize(name());
 
         if (connectionUrls.isPresent()) {
             for (int i = 0; i < connectionUrls.get(); i++) {
-                String connectionUrl = ConfigurationUtil.getInstance().get("kumuluzee.health.checks" +
-                        ".http-health-check[" + i + "].connection-url").orElse("");
+                String connectionUrl = ConfigurationUtil.getInstance().get(name() + "[" + i + "].connection-url").orElse("");
                 checkHttpStatus(connectionUrl, healthCheckResponseBuilder);
             }
         } else {
-            String connectionUrl = ConfigurationUtil.getInstance().get("kumuluzee.health.checks.http-health-check" +
-                    ".connection-url").orElse("");
+            String connectionUrl = ConfigurationUtil.getInstance().get(name() + ".connection-url").orElse("");
             checkHttpStatus(connectionUrl, healthCheckResponseBuilder);
         }
 

--- a/src/main/java/com/kumuluz/ee/health/checks/KumuluzHealthCheck.java
+++ b/src/main/java/com/kumuluz/ee/health/checks/KumuluzHealthCheck.java
@@ -1,0 +1,11 @@
+package com.kumuluz.ee.health.checks;
+
+public abstract class KumuluzHealthCheck {
+
+    protected String kumuluzBaseHealthConfigPath = "kumuluzee.health.checks.";
+
+    public abstract String name();
+
+    public abstract boolean initSuccess();
+
+}

--- a/src/main/java/com/kumuluz/ee/health/checks/KumuluzHealthCheck.java
+++ b/src/main/java/com/kumuluz/ee/health/checks/KumuluzHealthCheck.java
@@ -1,11 +1,56 @@
+/*
+ *  Copyright (c) 2014-2017 Kumuluz and/or its affiliates
+ *  and other contributors as indicated by the @author tags and
+ *  the contributor list.
+ *
+ *  Licensed under the MIT License (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  https://opensource.org/licenses/MIT
+ *
+ *  The software is provided "AS IS", WITHOUT WARRANTY OF ANY KIND, express or
+ *  implied, including but not limited to the warranties of merchantability,
+ *  fitness for a particular purpose and noninfringement. in no event shall the
+ *  authors or copyright holders be liable for any claim, damages or other
+ *  liability, whether in an action of contract, tort or otherwise, arising from,
+ *  out of or in connection with the software or the use or other dealings in the
+ *  software. See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
 package com.kumuluz.ee.health.checks;
 
+import com.kumuluz.ee.configuration.utils.ConfigurationUtil;
+import com.kumuluz.ee.health.enums.HealthCheckType;
+
+import java.util.logging.Logger;
+
+/**
+ * @author gpor0
+ * @since 2.1.0
+ */
 public abstract class KumuluzHealthCheck {
+
+    private static final Logger LOG = Logger.getLogger(KumuluzHealthCheck.class.getName());
 
     protected String kumuluzBaseHealthConfigPath = "kumuluzee.health.checks.";
 
     public abstract String name();
 
     public abstract boolean initSuccess();
+
+    public HealthCheckType getHealthCheckType() {
+        String type = ConfigurationUtil.getInstance().get(name() + ".type").orElse("readiness");
+
+        HealthCheckType parsedType = HealthCheckType.parse(type);
+
+        if (parsedType == null) {
+            LOG.severe("Type of the health check " + name() + " is invalid (" + type + "). Using the " +
+                    "default type: readiness.");
+            parsedType = HealthCheckType.READINESS;
+        }
+
+        return parsedType;
+    }
 
 }

--- a/src/main/java/com/kumuluz/ee/health/checks/MongoHealthCheck.java
+++ b/src/main/java/com/kumuluz/ee/health/checks/MongoHealthCheck.java
@@ -17,15 +17,17 @@
  *  out of or in connection with the software or the use or other dealings in the
  *  software. See the License for the specific language governing permissions and
  *  limitations under the License.
-*/
+ */
 package com.kumuluz.ee.health.checks;
 
 import com.kumuluz.ee.configuration.utils.ConfigurationUtil;
+import com.kumuluz.ee.health.annotations.BuiltInHealthCheck;
 import com.mongodb.MongoClient;
 import com.mongodb.MongoClientURI;
 import org.eclipse.microprofile.health.HealthCheck;
 import org.eclipse.microprofile.health.HealthCheckResponse;
 
+import javax.enterprise.context.ApplicationScoped;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -35,7 +37,9 @@ import java.util.logging.Logger;
  * @author Marko Škrjanec
  * @since 1.0.0
  */
-public class MongoHealthCheck implements HealthCheck {
+@ApplicationScoped
+@BuiltInHealthCheck
+public class MongoHealthCheck extends KumuluzHealthCheck implements HealthCheck {
 
     private static final Logger LOG = Logger.getLogger(MongoHealthCheck.class.getName());
 
@@ -89,5 +93,21 @@ public class MongoHealthCheck implements HealthCheck {
         }
 
         return false;
+    }
+
+    @Override
+    public String name() {
+        return kumuluzBaseHealthConfigPath + "mongo-health-check";
+    }
+
+    @Override
+    public boolean initSuccess() {
+        try {
+            Class.forName("com.mongodb.MongoClient");
+            return true;
+        } catch (ClassNotFoundException e) {
+            LOG.severe("The required mongo-java-driver library appears to be missing.");
+            return false;
+        }
     }
 }

--- a/src/main/java/com/kumuluz/ee/health/checks/MongoHealthCheck.java
+++ b/src/main/java/com/kumuluz/ee/health/checks/MongoHealthCheck.java
@@ -49,7 +49,7 @@ public class MongoHealthCheck extends KumuluzHealthCheck implements HealthCheck 
     @Override
     public HealthCheckResponse call() {
         String connectionUrl = ConfigurationUtil.getInstance()
-                .get("kumuluzee.health.checks.mongo-health-check.connection-url")
+                .get(name() + ".connection-url")
                 .orElse(DEFAULT_MONGO_URL);
 
         MongoClient mongoClient = null;
@@ -59,14 +59,14 @@ public class MongoHealthCheck extends KumuluzHealthCheck implements HealthCheck 
             mongoClient = new MongoClient(mongoClientURI);
 
             if (databaseExist(mongoClient, mongoClientURI.getDatabase())) {
-                return HealthCheckResponse.named(MongoHealthCheck.class.getSimpleName()).up().build();
+                return HealthCheckResponse.up(MongoHealthCheck.class.getSimpleName());
             } else {
                 LOG.severe("Mongo database not found.");
-                return HealthCheckResponse.named(MongoHealthCheck.class.getSimpleName()).down().build();
+                return HealthCheckResponse.down(MongoHealthCheck.class.getSimpleName());
             }
         } catch (Exception exception) {
             LOG.log(Level.SEVERE, "An exception occurred when trying to establish connection to Mongo.", exception);
-            return HealthCheckResponse.named(MongoHealthCheck.class.getSimpleName()).down().build();
+            return HealthCheckResponse.down(MongoHealthCheck.class.getSimpleName());
         } finally {
             if (mongoClient != null) {
                 mongoClient.close();

--- a/src/main/java/com/kumuluz/ee/health/checks/RabbitHealthCheck.java
+++ b/src/main/java/com/kumuluz/ee/health/checks/RabbitHealthCheck.java
@@ -21,11 +21,13 @@
 package com.kumuluz.ee.health.checks;
 
 import com.kumuluz.ee.configuration.utils.ConfigurationUtil;
+import com.kumuluz.ee.health.annotations.BuiltInHealthCheck;
 import com.rabbitmq.client.Connection;
 import com.rabbitmq.client.ConnectionFactory;
 import org.eclipse.microprofile.health.HealthCheck;
 import org.eclipse.microprofile.health.HealthCheckResponse;
 
+import javax.enterprise.context.ApplicationScoped;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -35,7 +37,9 @@ import java.util.logging.Logger;
  * @author Marko Škrjanec
  * @since 1.0.0
  */
-public class RabbitHealthCheck implements HealthCheck {
+@ApplicationScoped
+@BuiltInHealthCheck
+public class RabbitHealthCheck extends KumuluzHealthCheck implements HealthCheck {
 
     private static final Logger LOG = Logger.getLogger(RabbitHealthCheck.class.getName());
 
@@ -66,6 +70,22 @@ public class RabbitHealthCheck implements HealthCheck {
                             exception);
                 }
             }
+        }
+    }
+
+    @Override
+    public String name() {
+        return kumuluzBaseHealthConfigPath+"rabbit-health-check";
+    }
+
+    @Override
+    public boolean initSuccess() {
+        try {
+            Class.forName("com.rabbitmq.client.Connection");
+            return true;
+        } catch (ClassNotFoundException e) {
+            LOG.severe("The required amqp-client library appears to be missing.");
+            return false;
         }
     }
 }

--- a/src/main/java/com/kumuluz/ee/health/checks/RabbitHealthCheck.java
+++ b/src/main/java/com/kumuluz/ee/health/checks/RabbitHealthCheck.java
@@ -17,7 +17,7 @@
  *  out of or in connection with the software or the use or other dealings in the
  *  software. See the License for the specific language governing permissions and
  *  limitations under the License.
-*/
+ */
 package com.kumuluz.ee.health.checks;
 
 import com.kumuluz.ee.configuration.utils.ConfigurationUtil;
@@ -49,7 +49,7 @@ public class RabbitHealthCheck extends KumuluzHealthCheck implements HealthCheck
     @Override
     public HealthCheckResponse call() {
         String connectionUrl = ConfigurationUtil.getInstance()
-                .get("kumuluzee.health.checks.rabbit-health-check.connection-url")
+                .get(name() + ".connection-url")
                 .orElse(DEFAULT_RABBIT_URL);
 
         Connection connection = null;
@@ -57,10 +57,10 @@ public class RabbitHealthCheck extends KumuluzHealthCheck implements HealthCheck
             ConnectionFactory factory = new ConnectionFactory();
             factory.setUri(connectionUrl);
             connection = factory.newConnection();
-            return HealthCheckResponse.named(RabbitHealthCheck.class.getSimpleName()).up().build();
+            return HealthCheckResponse.up(RabbitHealthCheck.class.getSimpleName());
         } catch (Exception exception) {
             LOG.log(Level.SEVERE, "An exception occurred when trying to establish connection to RabbitMQ.", exception);
-            return HealthCheckResponse.named(RabbitHealthCheck.class.getSimpleName()).down().build();
+            return HealthCheckResponse.down(RabbitHealthCheck.class.getSimpleName());
         } finally {
             if (connection != null) {
                 try {
@@ -75,7 +75,7 @@ public class RabbitHealthCheck extends KumuluzHealthCheck implements HealthCheck
 
     @Override
     public String name() {
-        return kumuluzBaseHealthConfigPath+"rabbit-health-check";
+        return kumuluzBaseHealthConfigPath + "rabbit-health-check";
     }
 
     @Override

--- a/src/main/java/com/kumuluz/ee/health/checks/RedisHealthCheck.java
+++ b/src/main/java/com/kumuluz/ee/health/checks/RedisHealthCheck.java
@@ -17,14 +17,16 @@
  *  out of or in connection with the software or the use or other dealings in the
  *  software. See the License for the specific language governing permissions and
  *  limitations under the License.
-*/
+ */
 package com.kumuluz.ee.health.checks;
 
 import com.kumuluz.ee.configuration.utils.ConfigurationUtil;
+import com.kumuluz.ee.health.annotations.BuiltInHealthCheck;
 import org.eclipse.microprofile.health.HealthCheck;
 import org.eclipse.microprofile.health.HealthCheckResponse;
 import redis.clients.jedis.JedisPool;
 
+import javax.enterprise.context.ApplicationScoped;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -34,7 +36,9 @@ import java.util.logging.Logger;
  * @author Marko Škrjanec
  * @since 1.0.0
  */
-public class RedisHealthCheck implements HealthCheck {
+@ApplicationScoped
+@BuiltInHealthCheck
+public class RedisHealthCheck extends KumuluzHealthCheck implements HealthCheck {
 
     private static final Logger LOG = Logger.getLogger(RedisHealthCheck.class.getName());
 
@@ -59,6 +63,22 @@ public class RedisHealthCheck implements HealthCheck {
             if (pool != null) {
                 pool.close();
             }
+        }
+    }
+
+    @Override
+    public String name() {
+        return kumuluzBaseHealthConfigPath + "redis-health-check";
+    }
+
+    @Override
+    public boolean initSuccess() {
+        try {
+            Class.forName("redis.clients.jedis.JedisPool");
+            return true;
+        } catch (ClassNotFoundException e) {
+            LOG.severe("The required jedis library appears to be missing.");
+            return false;
         }
     }
 }

--- a/src/main/java/com/kumuluz/ee/health/checks/RedisHealthCheck.java
+++ b/src/main/java/com/kumuluz/ee/health/checks/RedisHealthCheck.java
@@ -47,18 +47,17 @@ public class RedisHealthCheck extends KumuluzHealthCheck implements HealthCheck 
 
     @Override
     public HealthCheckResponse call() {
-        String connectionUrl = ConfigurationUtil.getInstance()
-                .get("kumuluzee.health.checks.redis-health-check.connection-url")
+        String connectionUrl = ConfigurationUtil.getInstance().get(name() + ".connection-url")
                 .orElse(DEFAULT_REDIS_URL);
 
         JedisPool pool = null;
         try {
             pool = new JedisPool(connectionUrl);
             pool.getResource();
-            return HealthCheckResponse.named(RedisHealthCheck.class.getSimpleName()).up().build();
+            return HealthCheckResponse.up(RedisHealthCheck.class.getSimpleName());
         } catch (Exception exception) {
             LOG.log(Level.SEVERE, "An exception occurred when trying to establish connection to Redis.", exception);
-            return HealthCheckResponse.named(RedisHealthCheck.class.getSimpleName()).down().build();
+            return HealthCheckResponse.down(RedisHealthCheck.class.getSimpleName());
         } finally {
             if (pool != null) {
                 pool.close();

--- a/src/main/java/com/kumuluz/ee/health/utils/HealthCheckInitializationExtension.java
+++ b/src/main/java/com/kumuluz/ee/health/utils/HealthCheckInitializationExtension.java
@@ -17,12 +17,13 @@
  *  out of or in connection with the software or the use or other dealings in the
  *  software. See the License for the specific language governing permissions and
  *  limitations under the License.
-*/
+ */
 package com.kumuluz.ee.health.utils;
 
 import com.kumuluz.ee.configuration.utils.ConfigurationUtil;
 import com.kumuluz.ee.health.HealthRegistry;
-import com.kumuluz.ee.health.checks.*;
+import com.kumuluz.ee.health.annotations.BuiltInHealthCheck;
+import com.kumuluz.ee.health.checks.KumuluzHealthCheck;
 import com.kumuluz.ee.health.enums.HealthCheckType;
 import org.eclipse.microprofile.health.Health;
 import org.eclipse.microprofile.health.HealthCheck;
@@ -36,10 +37,7 @@ import javax.enterprise.inject.spi.Bean;
 import javax.enterprise.inject.spi.BeanManager;
 import javax.enterprise.inject.spi.Extension;
 import javax.enterprise.util.AnnotationLiteral;
-import java.sql.DriverManager;
 import java.util.Set;
-import java.util.function.Supplier;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -52,108 +50,55 @@ public class HealthCheckInitializationExtension implements Extension {
 
     private static final Logger LOG = Logger.getLogger(HealthCheckInitializationExtension.class.getName());
 
+    protected final String MP_HEALTH_DISABLE_DEFAULT_HEALTH = "mp.health.disable-default-procedures";
+
     public void registerHealthChecks(@Observes @Initialized(ApplicationScoped.class) Object init, BeanManager
             beanManager) {
 
-        // register classes that implement health checks
-
-        registerHealthCheck("kumuluzee.health.checks.data-source-health-check",
-                DataSourceHealthCheck.class,
-                () -> {
-                    if(!DriverManager.getDrivers().hasMoreElements()){
-                        LOG.severe("No database driver library appears to be provided.");
-                        return false;
-                    }
-
-                    return true;
-                });
-
-        registerHealthCheck("kumuluzee.health.checks.disk-space-health-check",
-                DiskSpaceHealthCheck.class,
-                () -> true);
-
-        registerHealthCheck("kumuluzee.health.checks.elastic-search-health-check",
-                ElasticSearchHealthCheck.class,
-                () -> true);
-
-        registerHealthCheck("kumuluzee.health.checks.etcd-health-check",
-                EtcdHealthCheck.class,
-                () -> true);
-
-        registerHealthCheck("kumuluzee.health.checks.http-health-check",
-                HttpHealthCheck.class,
-                () -> true);
-
-        registerHealthCheck("kumuluzee.health.checks.mongo-health-check",
-                MongoHealthCheck.class,
-                () -> {
-                    try {
-                        Class.forName( "com.mongodb.MongoClient" );
-                        return true;
-                    } catch( ClassNotFoundException e ) {
-                        LOG.severe("The required mongo-java-driver library appears to be missing.");
-                        return false;
-                    }
-                });
-
-        registerHealthCheck("kumuluzee.health.checks.rabbit-health-check",
-                RabbitHealthCheck.class,
-                () -> {
-                    try {
-                        Class.forName( "com.rabbitmq.client.Connection" );
-                        return true;
-                    } catch( ClassNotFoundException e ) {
-                        LOG.severe("The required amqp-client library appears to be missing.");
-                        return false;
-                    }
-                });
-
-        registerHealthCheck("kumuluzee.health.checks.redis-health-check",
-                RedisHealthCheck.class,
-                () -> {
-                    try {
-                        Class.forName( "redis.clients.jedis.JedisPool" );
-                        return true;
-                    } catch( ClassNotFoundException e ) {
-                        LOG.severe("The required jedis library appears to be missing.");
-                        return false;
-                    }
-                });
-
         // register beans that implement health checks
-        registerHealthCheckBeans(beanManager, new AnnotationLiteral<Liveness>() {}, HealthCheckType.LIVENESS);
-        registerHealthCheckBeans(beanManager, new AnnotationLiteral<Readiness>() {}, HealthCheckType.READINESS);
-        registerHealthCheckBeans(beanManager, new AnnotationLiteral<Health>() {}, HealthCheckType.BOTH);
+        registerHealthCheckBeans(beanManager, new AnnotationLiteral<Liveness>() {
+        }, HealthCheckType.LIVENESS);
+        registerHealthCheckBeans(beanManager, new AnnotationLiteral<Readiness>() {
+        }, HealthCheckType.READINESS);
+        registerHealthCheckBeans(beanManager, new AnnotationLiteral<Health>() {
+        }, HealthCheckType.BOTH);
+        registerHealthCheckBeans(beanManager, new AnnotationLiteral<BuiltInHealthCheck>() {
+        }, HealthCheckType.BOTH);
     }
 
     private void registerHealthCheckBeans(BeanManager beanManager, AnnotationLiteral qualifier, HealthCheckType type) {
         // register beans that implement health checks
         Set<Bean<?>> beans = beanManager.getBeans(HealthCheck.class, qualifier);
 
+        boolean disableDefaultHealthChecks = ConfigurationUtil.getInstance().getBoolean(MP_HEALTH_DISABLE_DEFAULT_HEALTH).orElse(false);
         for (Bean<?> bean : beans) {
+            if (bean.getBeanClass().isAnnotationPresent(BuiltInHealthCheck.class)) {
+                if (disableDefaultHealthChecks || !isBuildInHealthCheckValidForRegistration(bean)) {
+                    continue;
+                }
+            }
             HealthCheck healthCheckBean = (HealthCheck) beanManager.getReference(bean, HealthCheck.class,
                     beanManager.createCreationalContext(bean));
             HealthRegistry.getInstance().register(bean.getBeanClass().getSimpleName(), healthCheckBean, type);
         }
     }
 
-    private void registerHealthCheck(String configKeyPrefix, Class<? extends HealthCheck> healthCheckClass,
-                                     Supplier<Boolean> check) {
-        if (ConfigurationUtil.getInstance().get(configKeyPrefix).isPresent()) {
+    private boolean isBuildInHealthCheckValidForRegistration(Bean<?> bean) {
+        if (KumuluzHealthCheck.class.isAssignableFrom(bean.getBeanClass())) {
+            try {
+                KumuluzHealthCheck instance = (KumuluzHealthCheck) bean.getBeanClass().newInstance();
+                String kumuluzHealthCheckName = instance.name();
 
-            if (check.get()) {
-
-                try {
-                    HealthRegistry.getInstance().register(
-                            healthCheckClass.getSimpleName(),
-                            healthCheckClass.newInstance(),
-                            getHealthCheckType(configKeyPrefix));
-                } catch (InstantiationException | IllegalAccessException e) {
-                    LOG.log(Level.SEVERE, "Could not instantiate " + configKeyPrefix, e);
+                if (ConfigurationUtil.getInstance().get(kumuluzHealthCheckName).isPresent()) {
+                    if (instance.initSuccess()) {
+                        return true;
+                    }
                 }
+            } catch (Exception e) {
 
             }
         }
+        return false;
     }
 
     private HealthCheckType getHealthCheckType(String configKeyPrefix) {

--- a/src/main/java/com/kumuluz/ee/health/utils/HealthCheckInitializationExtension.java
+++ b/src/main/java/com/kumuluz/ee/health/utils/HealthCheckInitializationExtension.java
@@ -79,7 +79,7 @@ public class HealthCheckInitializationExtension implements Extension {
             }
             HealthCheck healthCheckBean = (HealthCheck) beanManager.getReference(bean, HealthCheck.class,
                     beanManager.createCreationalContext(bean));
-            HealthRegistry.getInstance().register(bean.getBeanClass().getSimpleName(), healthCheckBean, type);
+            HealthRegistry.getInstance().register(healthCheckBean.getClass().getSimpleName(), healthCheckBean, type);
         }
     }
 


### PR DESCRIPTION
- Disabling default vendor procedures
An implementation is allowed to supply a reasonable default (out-of-the-box) procedures as defined in the Health Check Procedures section. To disable all default vendor procedures users can specify a MicroProfile Config configuration property mp.health.disable-default-procedures to true. This allows the application to process and display only the user-defined health check procedures.

- Fixed a bug in health check registration by name where name did not respect multiple lambda expressions within single bean.