### PR TITLE
Added OpenAPI integration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,8 @@
 
         <kumuluzee.version>3.8.0</kumuluzee.version>
 
+        <kumuluzee-openapi-mp.version>1.3.0-SNAPSHOT</kumuluzee-openapi-mp.version>
+
         <microprofile-health.version>2.2</microprofile-health.version>
 
         <jackson.version>2.9.9</jackson.version>
@@ -137,6 +139,14 @@
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
             <version>${kafka-clients.version}</version>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- OpenAPI MP integration -->
+        <dependency>
+            <groupId>com.kumuluz.ee.openapi</groupId>
+            <artifactId>kumuluzee-openapi-mp</artifactId>
+            <version>${kumuluzee-openapi-mp.version}</version>
             <optional>true</optional>
         </dependency>
 

--- a/src/main/java/com/kumuluz/ee/health/HealthExtension.java
+++ b/src/main/java/com/kumuluz/ee/health/HealthExtension.java
@@ -29,6 +29,7 @@ import com.kumuluz.ee.common.wrapper.KumuluzServerWrapper;
 import com.kumuluz.ee.configuration.utils.ConfigurationUtil;
 import com.kumuluz.ee.health.enums.HealthCheckType;
 import com.kumuluz.ee.health.logs.HealthCheckLogger;
+import com.kumuluz.ee.health.utils.HealthServletMappingUtil;
 
 import java.util.Collections;
 import java.util.Optional;
@@ -74,16 +75,7 @@ public class HealthExtension implements Extension {
         ConfigurationUtil configurationUtil = ConfigurationUtil.getInstance();
 
         // initialize servlet mapping
-        String servletMapping = configurationUtil.get("kumuluzee.health.servlet.mapping").orElse("/health/*");
-
-        if (!servletMapping.endsWith("/*")) {
-            if (servletMapping.endsWith("/")) {
-                servletMapping += "*";
-            } else {
-                servletMapping += "/*";
-            }
-        }
-
+        String servletMapping = HealthServletMappingUtil.getMapping();
         LOG.info("Registering health servlet on " + servletMapping);
 
         // register servlet

--- a/src/main/java/com/kumuluz/ee/health/openapi/HealthOASFilter.java
+++ b/src/main/java/com/kumuluz/ee/health/openapi/HealthOASFilter.java
@@ -1,0 +1,156 @@
+/*
+ *  Copyright (c) 2014-2017 Kumuluz and/or its affiliates
+ *  and other contributors as indicated by the @author tags and
+ *  the contributor list.
+ *
+ *  Licensed under the MIT License (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  https://opensource.org/licenses/MIT
+ *
+ *  The software is provided "AS IS", WITHOUT WARRANTY OF ANY KIND, express or
+ *  implied, including but not limited to the warranties of merchantability,
+ *  fitness for a particular purpose and noninfringement. in no event shall the
+ *  authors or copyright holders be liable for any claim, damages or other
+ *  liability, whether in an action of contract, tort or otherwise, arising from,
+ *  out of or in connection with the software or the use or other dealings in the
+ *  software. See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.kumuluz.ee.health.openapi;
+
+import com.kumuluz.ee.configuration.utils.ConfigurationUtil;
+import com.kumuluz.ee.health.checks.DataSourceHealthCheck;
+import com.kumuluz.ee.health.utils.HealthServletMappingUtil;
+import io.smallrye.openapi.api.models.ComponentsImpl;
+import io.smallrye.openapi.api.models.OperationImpl;
+import io.smallrye.openapi.api.models.PathItemImpl;
+import io.smallrye.openapi.api.models.PathsImpl;
+import io.smallrye.openapi.api.models.media.ContentImpl;
+import io.smallrye.openapi.api.models.media.MediaTypeImpl;
+import io.smallrye.openapi.api.models.media.SchemaImpl;
+import io.smallrye.openapi.api.models.responses.APIResponseImpl;
+import io.smallrye.openapi.api.models.responses.APIResponsesImpl;
+import org.eclipse.microprofile.openapi.OASFilter;
+import org.eclipse.microprofile.openapi.models.OpenAPI;
+import org.eclipse.microprofile.openapi.models.Operation;
+import org.eclipse.microprofile.openapi.models.PathItem;
+import org.eclipse.microprofile.openapi.models.media.Content;
+import org.eclipse.microprofile.openapi.models.media.Schema;
+import org.eclipse.microprofile.openapi.models.responses.APIResponse;
+import org.eclipse.microprofile.openapi.models.responses.APIResponses;
+
+import javax.ws.rs.core.MediaType;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * If enabled through configuration key, adds /health, /health/live and /health/ready endpoints to OpenAPI.
+ *
+ * @author Urban Malc
+ * @since 2.3.0
+ */
+public class HealthOASFilter implements OASFilter {
+
+    private String servletMapping;
+
+    public HealthOASFilter() {
+        this.servletMapping = HealthServletMappingUtil.getMapping();
+
+        // remove trailing "/*"
+        this.servletMapping = this.servletMapping.substring(0, this.servletMapping.length() - 2);
+    }
+
+    private boolean isEnabled() {
+        return ConfigurationUtil.getInstance().getBoolean("kumuluzee.health.openapi-mp.enabled").orElse(false);
+    }
+
+    @Override
+    public void filterOpenAPI(OpenAPI openAPI) {
+
+        if (!isEnabled()) {
+            return;
+        }
+
+        if (openAPI.getComponents() == null) {
+            openAPI.components(new ComponentsImpl());
+        }
+        if (openAPI.getComponents().getSchemas() == null) {
+            openAPI.getComponents().schemas(new HashMap<>());
+        }
+        if (openAPI.getPaths() == null) {
+            openAPI.paths(new PathsImpl());
+        }
+
+        Schema healthStatusSchema = new SchemaImpl();
+        healthStatusSchema.setType(Schema.SchemaType.STRING);
+        healthStatusSchema.setEnumeration(Arrays.asList(new String[]{"UP", "DOWN"}));
+        healthStatusSchema.setExample("UP/DOWN"); // looks better in examples
+        openAPI.getComponents().getSchemas().put("HealthStatus", healthStatusSchema);
+
+        Schema healthCheckSchema = new SchemaImpl();
+        healthCheckSchema.setType(Schema.SchemaType.OBJECT);
+        Map<String, Schema> healthCheckSchemaProperties = new HashMap<>();
+        healthCheckSchemaProperties.put("name", new SchemaImpl()
+                .type(Schema.SchemaType.STRING)
+                .example(DataSourceHealthCheck.class.getSimpleName()));
+        healthCheckSchemaProperties.put("status", new SchemaImpl()
+                .ref("#/components/schemas/HealthStatus"));
+        healthCheckSchemaProperties.put("data", new SchemaImpl()
+                .type(Schema.SchemaType.OBJECT)
+                .nullable(true));
+        healthCheckSchema.setProperties(healthCheckSchemaProperties);
+
+
+        Schema healthResponseSchema = new SchemaImpl();
+        healthResponseSchema.setType(Schema.SchemaType.OBJECT);
+        Map<String, Schema> healthResponseSchemaProperties = new HashMap<>();
+        healthResponseSchemaProperties.put("status", new SchemaImpl()
+                .ref("#/components/schemas/HealthStatus"));
+        healthResponseSchemaProperties.put("checks", new SchemaImpl()
+                .type(Schema.SchemaType.ARRAY)
+                .items(healthCheckSchema));
+        healthResponseSchema.setProperties(healthResponseSchemaProperties);
+        openAPI.getComponents().getSchemas().put("HealthResponse", healthResponseSchema);
+
+        PathItem healthPath = createHealthPath("Get information about the health of this service",
+                "Contains both readiness and liveness checks.");
+        openAPI.getPaths().addPathItem(this.servletMapping, healthPath);
+        PathItem healthReadyPath = createHealthPath("Get information about the readiness of this service",
+                null);
+        openAPI.getPaths().addPathItem(this.servletMapping + "/ready", healthReadyPath);
+        PathItem healthLivePath = createHealthPath("Get information about the liveness of this service",
+                null);
+        openAPI.getPaths().addPathItem(this.servletMapping + "/live", healthLivePath);
+    }
+
+    private PathItem createHealthPath(String summary, String description) {
+        Content healthResponseContent = new ContentImpl();
+        healthResponseContent.addMediaType(MediaType.APPLICATION_JSON, new MediaTypeImpl().schema(new SchemaImpl()
+                .ref("#/components/schemas/HealthResponse")));
+
+        PathItem healthPath = new PathItemImpl();
+        Operation healthGet = new OperationImpl();
+        healthGet.addTag("health");
+        healthGet.summary(summary);
+        healthGet.description(description);
+        APIResponses healthResponses = new APIResponsesImpl();
+        APIResponse health200 = new APIResponseImpl();
+        health200.description("The service is healthy");
+        health200.content(healthResponseContent);
+        healthResponses.addAPIResponse("200", health200);
+        APIResponse health503 = new APIResponseImpl();
+        health503.description("The service is not healthy");
+        health503.content(healthResponseContent);
+        healthResponses.addAPIResponse("503", health503);
+        APIResponse health500 = new APIResponseImpl();
+        health500.description("Server error while evaluating health checks");
+        healthResponses.addAPIResponse("500", health500);
+        healthGet.responses(healthResponses);
+        healthPath.setGET(healthGet);
+
+        return healthPath;
+    }
+}

--- a/src/main/java/com/kumuluz/ee/health/openapi/HealthOASFilterProvider.java
+++ b/src/main/java/com/kumuluz/ee/health/openapi/HealthOASFilterProvider.java
@@ -1,0 +1,38 @@
+/*
+ *  Copyright (c) 2014-2017 Kumuluz and/or its affiliates
+ *  and other contributors as indicated by the @author tags and
+ *  the contributor list.
+ *
+ *  Licensed under the MIT License (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  https://opensource.org/licenses/MIT
+ *
+ *  The software is provided "AS IS", WITHOUT WARRANTY OF ANY KIND, express or
+ *  implied, including but not limited to the warranties of merchantability,
+ *  fitness for a particular purpose and noninfringement. in no event shall the
+ *  authors or copyright holders be liable for any claim, damages or other
+ *  liability, whether in an action of contract, tort or otherwise, arising from,
+ *  out of or in connection with the software or the use or other dealings in the
+ *  software. See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.kumuluz.ee.health.openapi;
+
+import com.kumuluz.ee.openapi.mp.spi.OasFilterProvider;
+import org.eclipse.microprofile.openapi.OASFilter;
+
+/**
+ * OpenAPI OAS Filter Provider SPI implementation.
+ *
+ * @author Urban Malc
+ * @since 2.3.0
+ */
+public class HealthOASFilterProvider implements OasFilterProvider {
+
+    @Override
+    public OASFilter registerOasFilter() {
+        return new HealthOASFilter();
+    }
+}

--- a/src/main/java/com/kumuluz/ee/health/utils/HealthServletMappingUtil.java
+++ b/src/main/java/com/kumuluz/ee/health/utils/HealthServletMappingUtil.java
@@ -1,0 +1,47 @@
+/*
+ *  Copyright (c) 2014-2017 Kumuluz and/or its affiliates
+ *  and other contributors as indicated by the @author tags and
+ *  the contributor list.
+ *
+ *  Licensed under the MIT License (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  https://opensource.org/licenses/MIT
+ *
+ *  The software is provided "AS IS", WITHOUT WARRANTY OF ANY KIND, express or
+ *  implied, including but not limited to the warranties of merchantability,
+ *  fitness for a particular purpose and noninfringement. in no event shall the
+ *  authors or copyright holders be liable for any claim, damages or other
+ *  liability, whether in an action of contract, tort or otherwise, arising from,
+ *  out of or in connection with the software or the use or other dealings in the
+ *  software. See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.kumuluz.ee.health.utils;
+
+import com.kumuluz.ee.configuration.utils.ConfigurationUtil;
+
+/**
+ * Utility for getting health servlet mapping from configuration framework and cleaning it up.
+ *
+ * @author Urban Malc
+ * @since 2.3.0
+ */
+public class HealthServletMappingUtil {
+
+    public static String getMapping() {
+        String servletMapping = ConfigurationUtil.getInstance()
+                .get("kumuluzee.health.servlet.mapping").orElse("health");
+
+        // strip "/"
+        while (servletMapping.startsWith("/")) {
+            servletMapping = servletMapping.substring(1);
+        }
+        while (servletMapping.endsWith("/")) {
+            servletMapping = servletMapping.substring(0, servletMapping.length() - 1);
+        }
+
+        return "/" + servletMapping + "/*";
+    }
+}

--- a/src/main/resources/META-INF/services/com.kumuluz.ee.openapi.mp.spi.OasFilterProvider
+++ b/src/main/resources/META-INF/services/com.kumuluz.ee.openapi.mp.spi.OasFilterProvider
@@ -1,0 +1,1 @@
+com.kumuluz.ee.health.openapi.HealthOASFilterProvider


### PR DESCRIPTION
If enabled with `kumuluzee.health.openapi-mp.enabled` then adds endpoints `/health`, `/health/live` and `/health/ready` to existing OpenAPI model.

Generated model looks like this:

```yaml
---
openapi: 3.0.1
info:
  title: Generated API
  version: "1.0"
paths:
  /health:
    get:
      tags:
      - health
      summary: Get information about the health of this service
      description: Contains both readiness and liveness checks.
      responses:
        "200":
          description: The service is healthy
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/HealthResponse'
        "503":
          description: The service is not healthy
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/HealthResponse'
        "500":
          description: Server error while evaluating health checks
  /health/ready:
    get:
      tags:
      - health
      summary: Get information about the readiness of this service
      responses:
        "200":
          description: The service is healthy
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/HealthResponse'
        "503":
          description: The service is not healthy
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/HealthResponse'
        "500":
          description: Server error while evaluating health checks
  /health/live:
    get:
      tags:
      - health
      summary: Get information about the liveness of this service
      responses:
        "200":
          description: The service is healthy
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/HealthResponse'
        "503":
          description: The service is not healthy
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/HealthResponse'
        "500":
          description: Server error while evaluating health checks
components:
  schemas:
    HealthStatus:
      enum:
      - UP
      - DOWN
      type: string
      example: UP/DOWN
    HealthResponse:
      type: object
      properties:
        checks:
          type: array
          items:
            type: object
            properties:
              data:
                type: object
                nullable: true
              name:
                type: string
                example: DataSourceHealthCheck
              status:
                $ref: '#/components/schemas/HealthStatus'
        status:
          $ref: '#/components/schemas/HealthStatus'
```

Depends on: https://github.com/kumuluz/kumuluzee-openapi-mp/pull/10